### PR TITLE
Removing image_url as depreciated

### DIFF
--- a/block_admin_presets.php
+++ b/block_admin_presets.php
@@ -27,17 +27,17 @@ class block_admin_presets extends block_list {
             return $this->content;
         }
 
-        $this->content->items[] = '<img src="'.$OUTPUT->image_url("i/backup") . '" class="icon" alt="'.get_string('actionexport', 'block_admin_presets').'" />
-                                   <a title="'.get_string('actionexport', 'block_admin_presets').'" href="'.$CFG->wwwroot.'/blocks/admin_presets/index.php?action=export">
-                                   '.get_string('actionexport', 'block_admin_presets').'</a>';
+        $this->content->items[] = $OUTPUT->pix_icon("i/backup", get_string('actionexport', 'block_admin_presets'), "moodle", array("class" => "icon")) . 
+                                   '<a title="'.get_string('actionexport', 'block_admin_presets').'" href="'
+								   .$CFG->wwwroot.'/blocks/admin_presets/index.php?action=export">'.get_string('actionexport', 'block_admin_presets').'</a>';
 
-        $this->content->items[] = '<img src="'.$OUTPUT->image_url("i/restore").'" class="icon" alt="'.get_string('actionimport', 'block_admin_presets').'" />
-                                   <a title="'.get_string('actionimport', 'block_admin_presets').'" href="'.$CFG->wwwroot.'/blocks/admin_presets/index.php?action=import">
-                                   '.get_string('actionimport', 'block_admin_presets').'</a>';
+        $this->content->items[] = $OUTPUT->pix_icon("i/restore", get_string('actionimport', 'block_admin_presets'), "moodle", array("class" => "icon")) .
+                                   '<a title="'.get_string('actionimport', 'block_admin_presets').'" href="'
+								   .$CFG->wwwroot.'/blocks/admin_presets/index.php?action=import">'.get_string('actionimport', 'block_admin_presets').'</a>';
 
-        $this->content->items[] = '<img src="'.$OUTPUT->image_url("i/repository").'" class="icon" alt="'.get_string('actionbase', 'block_admin_presets').'" />
-                                   <a title="'.get_string('actionbase', 'block_admin_presets').'" href="'.$CFG->wwwroot.'/blocks/admin_presets/index.php">
-                                   '.get_string('actionbase', 'block_admin_presets').'</a>';
+        $this->content->items[] = $OUTPUT->pix_icon("i/repository", get_string('actionbase', 'block_admin_presets'), "moodle", array("class" => "icon")) .
+                                   '<a title="'.get_string('actionbase', 'block_admin_presets').'" href="'.
+								   $CFG->wwwroot.'/blocks/admin_presets/index.php">'.get_string('actionbase', 'block_admin_presets').'</a>';
 
         return $this->content;
     }

--- a/forms/admin_presets_export_form.php
+++ b/forms/admin_presets_export_form.php
@@ -29,7 +29,7 @@ class admin_presets_export_form extends moodleform {
 
         // Moodle settings table
         $mform->addElement('header', 'general', get_string('adminsettings', 'block_admin_presets'));
-        $mform->addElement('html', '<div id="settings_tree_div" class="ygtv-checkbox"><img src="'.$OUTPUT->image_url('i/loading_small').'"/></div><br/>');
+        $mform->addElement('html', '<div id="settings_tree_div" class="ygtv-checkbox">'.$OUTPUT->pix_icon('i/loading_small', get_string('loading', 'block_admin_presets'), "moodle").'</div><br/>');
 
         // Submit
         $mform->addElement('submit', 'admin_presets_submit', get_string('savechanges'));

--- a/forms/admin_presets_load_form.php
+++ b/forms/admin_presets_load_form.php
@@ -27,7 +27,7 @@ class admin_presets_load_form extends moodleform {
         if (!$this->preview) {
             $class = 'ygtv-checkbox';
         }
-        $mform->addElement('html', '<div id="settings_tree_div" class="'.$class.'"><img src="'.$OUTPUT->image_url('i/loading_small').'"/></div>');
+        $mform->addElement('html', '<div id="settings_tree_div" class="'.$class.'">'.$OUTPUT->pix_url('i/loading_small', get_string('loading', 'block_admin_presets')).'</div>');
 
         $mform->addElement('hidden', 'id');
         $mform->setType('id', PARAM_INT);

--- a/lang/en/block_admin_presets.php
+++ b/lang/en/block_admin_presets.php
@@ -39,6 +39,7 @@ $string['imported'] = 'Imported';
 $string['importexecute'] = 'importing';
 $string['importshow'] = 'select file';
 $string['load'] = 'load';
+$string['loading'] = 'loading';
 $string['loadexecute'] = 'applied changes';
 $string['loadpreview'] = 'preview preset';
 $string['loadselected'] = 'Load selected settings';


### PR DESCRIPTION
Hey

Doing some theme dev and using your plugin to copy settings around. Opted to turn on the extreme debugging option and noticed some errors and coded them out. This commit might be useful  - wasn't a lot of work but felt best to share if it helps you out

Feedback welcome

Pat