### PR TITLE
311 multi files

### DIFF
--- a/lib/admin_presets_base.class.php
+++ b/lib/admin_presets_base.class.php
@@ -430,7 +430,6 @@ class admin_presets_base {
                 }
             }
         }
-
         return $settings;
     }
 

--- a/lib/admin_presets_export.class.php
+++ b/lib/admin_presets_export.class.php
@@ -184,7 +184,7 @@ class admin_presets_export extends admin_presets_base {
 
                 $tagname = strtoupper($plugin);
 
-                // To aviod xml slash problems.
+                // To avoid xml slash problems.
                 if (strstr($tagname, '/') != false) {
                     $tagname = str_replace('/', '__', $tagname);
                 }
@@ -209,7 +209,7 @@ class admin_presets_export extends admin_presets_base {
                             }
                         }
 
-                        $xmlwriter->full_tag(strtoupper($setting->name), $setting->value, $attributes);
+                        $xmlwriter->full_tag(strtoupper(trim($setting->name)), trim($setting->value), $attributes);
                     }
 
                     $xmlwriter->end_tag('SETTINGS');

--- a/lib/admin_presets_load.class.php
+++ b/lib/admin_presets_load.class.php
@@ -59,7 +59,7 @@ class admin_presets_load extends admin_presets_base {
             // Only for selected items.
             $appliedchanges = array();
             $unnecessarychanges = array();
-            foreach (filter_input_array(INPUT_POST) as $varname => $value) {
+            foreach ($_POST as $varname => $value) {
 
                 unset($updatesetting);
 
@@ -147,6 +147,8 @@ class admin_presets_load extends admin_presets_base {
                         $appliedchanges[$varname]->visiblename = $presetsetting->get_settingdata()->visiblename;
                         $appliedchanges[$varname]->oldvisiblevalue = $sitesetting->get_visiblevalue();
                         $appliedchanges[$varname]->visiblevalue = $presetsetting->get_visiblevalue();
+
+                        purge_caches();
 
                         // Unnecessary changes (actual setting value).
                     } else {

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021052700;
+$plugin->version = 2021052701;
 $plugin->requires = 2016052300;        // Requires this Moodle version
 $plugin->component = 'block_admin_presets';
 $plugin->release = '3.4';


### PR DESCRIPTION
Manage files parameters (single or multi) with preview (image or truncated text for css or other file extension).

File data (content, extension, filename) stored as base64 with separators in plugin tables and xml

new class admin_preset_admin_setting_configstoredfile

fileareaMapping function for plugins where filearea name is not equal to parameter name